### PR TITLE
ci: bump GitHub Actions to Node 24 compatible versions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,15 +17,15 @@ jobs:
         node-version: ['20.x', '22.x', '24.x']
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
 
       - name: Cache CDK Dependency
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: cache_cdk_dependency_id
         env:
           cache-name: cache-cdk-dependency-${{ matrix.node-version }}


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` v4 → v6
- Bump `actions/setup-node` v4 → v6
- Bump `actions/cache` v4 → v5

## Why
Current v4 releases run on Node.js 20, which is deprecated on GitHub Actions:
- 2026-06-02: runner forces Node 24 by default
- 2026-09-16: Node 20 removed from the runner

The bumped versions support Node 24 natively, silencing the deprecation warnings and future-proofing CI.

## Note
Stacked on top of PR #168 (matrix fix). Base branch is `claude/nothing-design-redesign`; GitHub will auto-retarget to `main` once PR #168 merges.

## Test plan
- [x] CI passes on this branch (`build.yaml` run on 20.x / 22.x / 24.x)
- [x] No more Node.js 20 deprecation warnings in annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)