### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,15 +17,15 @@ jobs:
         node-version: ['20.x', '22.x', '24.x']
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
 
       - name: Cache CDK Dependency
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: cache_cdk_dependency_id
         env:
           cache-name: cache-cdk-dependency-${{ matrix.node-version }}


### PR DESCRIPTION
## 概要

`.github/workflows/build.yaml` で使用している各 GitHub Actions の参照を、可変なタグ参照（`@v6` など）から不変なコミット SHA 参照に変更し、サプライチェーンの安全性を高める。バージョンは末尾コメントで併記する。

## 変更内容

- `actions/checkout` `@v6` → `@de0fac2e4500dabe0009e67214ff5f5447ce83dd` (v6.0.2)
- `actions/setup-node` `@v6` → `@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e` (v6.4.0)
- `actions/cache` `@v5` → `@27d5ce7f107fe9357f9df03efb73ab90386fccae` (v5.0.5)

## 影響範囲 / 注意点

- 振る舞いの変更なし。指していた実体（コミット）は最新リリースの SHA に固定。
- 今後の更新は Dependabot（`updates: github-actions`）等で SHA を追従させる運用を推奨。

## 動作確認

未実施（CI 上でのワークフロー実行で確認）。