### PR TITLE
fix: align auth token handling with refresh token rotation API

### DIFF
--- a/src/application/usecases/MembersUseCaseImpl.ts
+++ b/src/application/usecases/MembersUseCaseImpl.ts
@@ -27,18 +27,14 @@ class MembersUseCaseImpl extends BaseUseCase implements MembersUseCase {
 
   isLoggedIn = async () => {
     try {
-      if (!credentials.hasToken()) {
+      if (!credentials.hasToken() && !credentials.hasRefreshToken()) {
         return false
       }
-      let user = await this.repository.status()
-      if (!!!user) {
-        if (credentials.hasRefreshToken()) {
-          await this.repository.accessToken()
-          user = await this.repository.status()
-        }
-        if (!!!user) {
-          return false
-        }
+      // アクセストークンが失効していてもリフレッシュトークンが有効なら
+      // サーバー側で新しいトークンが再発行され、レスポンスヘッダー経由で保存される
+      const user = await this.repository.status()
+      if (!user) {
+        return false
       }
       this.updateCredential(user)
       return true

--- a/src/domain/repositories/MembersRepository.ts
+++ b/src/domain/repositories/MembersRepository.ts
@@ -11,8 +11,6 @@ interface MembersRepository {
   status(): Promise<UserVo>
 
   permissions(): Promise<FunctionVo>
-
-  accessToken(): Promise<void>
 }
 
 export default MembersRepository

--- a/src/infrastructure/http/BaseRepository.ts
+++ b/src/infrastructure/http/BaseRepository.ts
@@ -141,12 +141,16 @@ abstract class BaseRepository {
     responseAsBlob?: boolean,
     responseAsJson?: boolean
   ) => {
-    let baseHeaders = {}
+    const baseHeaders: Record<string, string> = {}
     if (!!auth || this.needsAuth) {
-      baseHeaders = {
-        Authorization: `Bearer ${Credentials.getToken()}`,
-        "X-Workspace-Id": Credentials.getWorkspaceId(),
-        "X-Refresh-Token": Credentials.getRefreshToken(),
+      baseHeaders["Authorization"] = `Bearer ${Credentials.getToken()}`
+      const workspaceId = Credentials.getWorkspaceId()
+      if (workspaceId) {
+        baseHeaders["X-Workspace-Id"] = workspaceId
+      }
+      const refreshToken = Credentials.getRefreshToken()
+      if (refreshToken) {
+        baseHeaders["X-Refresh-Token"] = refreshToken
       }
     }
 

--- a/src/infrastructure/repositories/MembersRepositoryImpl.ts
+++ b/src/infrastructure/repositories/MembersRepositoryImpl.ts
@@ -23,8 +23,4 @@ export default class MembersRepositoryImpl
   permissions = async () => {
     return await this._get({ path: "/permissions", hasResponse: true })
   }
-
-  accessToken = async () => {
-    await this._post({ path: "/access-token" })
-  }
 }

--- a/src/infrastructure/state/Credentials.ts
+++ b/src/infrastructure/state/Credentials.ts
@@ -50,7 +50,8 @@ export const Credentials = {
   },
 
   has(key: Keys) {
-    return Credentials.get(key) !== undefined
+    const value = Credentials.get(key)
+    return value !== null && value !== ""
   },
 
   set(key: Keys, value: string) {


### PR DESCRIPTION
## 概要

openreports-api [#281](https://github.com/ijufumi/openreports-api/pull/281)(refresh token の DB 永続化・ローテーション方式への変更)に合わせて、フロントエンドの認証周りを修正する。基本的なヘッダー処理(`X-Api-Token` / `X-Refresh-Token` を「レスポンスに存在する時だけ」保存する実装)は新仕様と互換のため、不整合のある箇所のみ修正した。

## 変更内容

- `Credentials.has()` が `localStorage.getItem()` の戻り値(無い場合 `null`)を `undefined` と比較していて常に `true` を返すバグを修正(`null` と空文字をチェック)
- 未保持のトークンを `"null"` という文字列リテラルとしてヘッダー送信しないよう、`X-Refresh-Token` / `X-Workspace-Id` は値がある時だけ付与するよう修正
- `isLoggedIn()` の到達不能だった `accessToken()` フォールバックを削除(401 時は `status()` が例外を投げるため実行されず、新仕様ではサーバーの before-filter がトークン再発行を透過的に行うため不要)。また、アクセストークンが無くてもリフレッシュトークンがあればログイン判定を試みるよう条件を緩和
- 不要になった `MembersRepository.accessToken()`(POST `/members/access-token`)を削除

## 影響範囲 / 注意点

- API 仕様の前提が openreports-api #281 のマージ・デプロイに依存する(ヘッダー名・CORS expose 設定は変更がないため、旧 API に対してもこの変更自体は後方互換)
- api 側のデプロイ時には旧 Redis ベースのリフレッシュトークンが無効になるため既存ユーザーは再ログインが必要(フロントは自動的にログイン画面へ誘導)

## 動作確認

- `npx tsc --noEmit` / ESLint / `npm run build` すべて成功
- 実 API との結合動作は未実施

🤖 Generated with [Claude Code](https://claude.com/claude-code)